### PR TITLE
[feat] SsufidPlugin crawl 메서드 명세 수정 및 TITLE, DESCRIPTION 상수 추가

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -67,9 +67,9 @@ impl SsufidCore {
             cache.insert(T::IDENTIFIER.to_string(), new_entries);
         }
         Ok(SsufidSiteData {
-            title: "TODO".to_string(), // T::TITLE
+            title: T::TITLE.to_string(),
             source: T::IDENTIFIER.to_string(),
-            description: "TODO".to_string(), // T::DESC
+            description: T::DESC.to_string(),
             items: updated_entries,
         })
     }
@@ -98,7 +98,10 @@ impl SsufidCore {
 }
 
 pub trait SsufidPlugin {
+    const TITLE: &'static str;
     const IDENTIFIER: &'static str;
+    const DESC: &'static str;
+
     fn crawl(
         &self,
     ) -> impl std::future::Future<Output = Result<Vec<SsufidPost>, SsufidError>> + Send;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -38,6 +38,8 @@ pub struct SsufidCore {
 }
 
 impl SsufidCore {
+    const POST_COUNT_LIMIT: u32 = 100;
+
     pub fn new(cache_dir: &str) -> Self {
         Self {
             cache: Arc::new(RwLock::new(HashMap::new())),
@@ -46,7 +48,7 @@ impl SsufidCore {
     }
 
     pub async fn run<T: SsufidPlugin>(&self, plugin: T) -> Result<SsufidSiteData, SsufidError> {
-        let new_entries = plugin.crawl().await?;
+        let new_entries = plugin.crawl(Self::POST_COUNT_LIMIT).await?;
         let cache = Arc::clone(&self.cache);
         let updated_entries = {
             // read lock scope
@@ -104,6 +106,7 @@ pub trait SsufidPlugin {
 
     fn crawl(
         &self,
+        max_post_cnt: u32,
     ) -> impl std::future::Future<Output = Result<Vec<SsufidPost>, SsufidError>> + Send;
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -71,7 +71,7 @@ impl SsufidCore {
         Ok(SsufidSiteData {
             title: T::TITLE.to_string(),
             source: T::IDENTIFIER.to_string(),
-            description: T::DESC.to_string(),
+            description: T::DESCRIPTION.to_string(),
             items: updated_entries,
         })
     }
@@ -102,11 +102,11 @@ impl SsufidCore {
 pub trait SsufidPlugin {
     const TITLE: &'static str;
     const IDENTIFIER: &'static str;
-    const DESC: &'static str;
+    const DESCRIPTION: &'static str;
 
     fn crawl(
         &self,
-        max_post_cnt: u32,
+        posts_limit: u32,
     ) -> impl std::future::Future<Output = Result<Vec<SsufidPost>, SsufidError>> + Send;
 }
 

--- a/src/core/rss.rs
+++ b/src/core/rss.rs
@@ -25,8 +25,7 @@ impl From<SsufidSiteData> for rss::Channel {
             .link(site.source)
             .description(site.description)
             .items(
-                site
-                    .items
+                site.items
                     .into_iter()
                     .map(SsufidPost::into)
                     .collect::<Vec<rss::Item>>(),

--- a/src/plugins/example.rs
+++ b/src/plugins/example.rs
@@ -5,11 +5,11 @@ pub struct ExamplePlugin;
 impl SsufidPlugin for ExamplePlugin {
     const TITLE: &'static str = "Example";
     const IDENTIFIER: &'static str = "example";
-    const DESC: &'static str = "Example plugin";
+    const DESCRIPTION: &'static str = "Example plugin";
 
     async fn crawl(
         &self,
-        #[allow(unused_variables)] max_post_cnt: u32,
+        #[allow(unused_variables)] posts_limit: u32,
     ) -> Result<Vec<crate::core::SsufidPost>, crate::core::SsufidError> {
         println!("example crawler!");
         Ok(vec![])

--- a/src/plugins/example.rs
+++ b/src/plugins/example.rs
@@ -3,7 +3,9 @@ use crate::core::SsufidPlugin;
 pub struct ExamplePlugin;
 
 impl SsufidPlugin for ExamplePlugin {
+    const TITLE: &'static str = "Example";
     const IDENTIFIER: &'static str = "example";
+    const DESC: &'static str = "Example plugin";
 
     async fn crawl(&self) -> Result<Vec<crate::core::SsufidPost>, crate::core::SsufidError> {
         println!("example crawler!");

--- a/src/plugins/example.rs
+++ b/src/plugins/example.rs
@@ -7,7 +7,10 @@ impl SsufidPlugin for ExamplePlugin {
     const IDENTIFIER: &'static str = "example";
     const DESC: &'static str = "Example plugin";
 
-    async fn crawl(&self) -> Result<Vec<crate::core::SsufidPost>, crate::core::SsufidError> {
+    async fn crawl(
+        &self,
+        #[allow(unused_variables)] max_post_cnt: u32,
+    ) -> Result<Vec<crate::core::SsufidPost>, crate::core::SsufidError> {
         println!("example crawler!");
         Ok(vec![])
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

Resolves #13 
Resolves #14 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- `SsufidPlugin`에 associated const 추가 (`TITLE`, `DESC`)
- `crawl` 메서드에 크롤링 할 게시글의 최대 개수를 제한하는 파라미터 추가

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- `crawl` 메서드에 추가한 파라미터 이름을 `max_posts_cnt`라고 지었는데 더 좋은 이름이 있을까요?
  - `SsufidCore`에 정의한 `POST_COUNT_LIMIT` 상수의 네이밍도 참고해주세요.