### PR TITLE
[feat] 컨텐츠 업데이트 감지 로직 작성

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, vec};
+use std::{collections::HashMap, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -6,7 +6,7 @@ use time;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::RwLock;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct SsufidPost {
     id: String,
     title: String,
@@ -17,7 +17,16 @@ pub struct SsufidPost {
     content: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+impl SsufidPost {
+    pub fn contents_eq(&self, other: &SsufidPost) -> bool {
+        self.id.trim() == other.id.trim()
+            && self.title.trim() == other.title.trim()
+            && self.category.trim() == other.category.trim()
+            && self.content.trim() == other.content.trim()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct SsufidSiteData {
     title: String,
     source: String,
@@ -57,14 +66,12 @@ impl SsufidCore {
                 None => &self.read_cache(T::IDENTIFIER).await?,
             };
 
-            // Compare with new and old: `updated_at` 설정
-            // and return the result
-            vec![]
+            inject_update_date(old_entries, new_entries)
         };
         {
             // write lock scope
             let mut cache = cache.write().await;
-            cache.insert(T::IDENTIFIER.to_string(), new_entries);
+            cache.insert(T::IDENTIFIER.to_string(), updated_entries.clone());
         }
         Ok(SsufidSiteData {
             title: "TODO".to_string(), // T::TITLE
@@ -95,6 +102,38 @@ impl SsufidCore {
         let items: Vec<SsufidPost> = serde_json::from_str(&content)?;
         Ok(items)
     }
+}
+
+fn inject_update_date(
+    old_entries: &[SsufidPost],
+    new_entries: impl IntoIterator<Item = SsufidPost>,
+) -> Vec<SsufidPost> {
+    let old_entries_map = old_entries
+        .iter()
+        .map(|post: &SsufidPost| (post.id.clone(), post))
+        .collect::<HashMap<String, &SsufidPost>>();
+    let current_time = time::OffsetDateTime::now_utc();
+    new_entries
+        .into_iter()
+        .map(|post| {
+            // 업데이트 정보를 플러그인이 제공했다면 자체 계산 제외
+            if post.updated_at.is_some() {
+                return post;
+            }
+            if let Some(old) = old_entries_map.get(&post.id) {
+                let old = *old;
+                if old.contents_eq(&post) {
+                    return post;
+                }
+                SsufidPost {
+                    updated_at: Some(current_time),
+                    ..post
+                }
+            } else {
+                post
+            }
+        })
+        .collect()
 }
 
 pub trait SsufidPlugin {


### PR DESCRIPTION
## #️⃣연관된 이슈

Resolves #16

## 📝작업 내용

- 게시글 업데이트 여부를 확인하고 업데이트 되었다면 `updated_at` 필드를 업데이트합니다.
- 이미 플러그인에서 업데이트 여부를 핸들링했다면 변경하지 않습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
