### PR TITLE
[fix] rfc3339를 이용해 OffsetDateTime을 (de)serialization 하도록 변경

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,7 +12,9 @@ pub struct SsufidPost {
     pub title: String,
     pub category: String,
     pub url: String,
+    #[serde(with = "time::serde::rfc3339")]
     pub created_at: time::OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339::option")]
     pub updated_at: Option<time::OffsetDateTime>,
     pub content: String,
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

Resolves #23 

## 📝작업 내용

`time::serde::rfc3339`를 이용해 json 직렬화가 [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.8) 로 이루어지도록 변경합니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
