### PR TITLE
[feat] 에러 처리 구조화

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,60 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("File I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Plugin(Box<PluginError>),
+}
+
+impl From<PluginError> for Error {
+    fn from(err: PluginError) -> Self {
+        Error::Plugin(Box::new(err))
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Error from plugin {plugin}: {kind:?} - {message}")]
+pub struct PluginError {
+    kind: PluginErrorKind,
+    plugin: String,
+    message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginErrorKind {
+    Request,
+    Parse,
+    Custom,
+}
+
+impl PluginError {
+    pub fn request(plugin: &str, message: String) -> Self {
+        Self {
+            kind: PluginErrorKind::Request,
+            plugin: plugin.to_string(),
+            message,
+        }
+    }
+
+    pub fn parse(plugin: &str, message: String) -> Self {
+        Self {
+            kind: PluginErrorKind::Parse,
+            plugin: plugin.to_string(),
+            message,
+        }
+    }
+
+    pub fn custom(plugin: &str, message: String) -> Self {
+        Self {
+            kind: PluginErrorKind::Custom,
+            plugin: plugin.to_string(),
+            message,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,9 @@
 pub mod core;
+pub mod error;
 pub mod plugins;
+
+pub use core::SsufidCore;
+
+pub use error::Error;
+pub use error::PluginError;
+pub use error::PluginErrorKind;

--- a/src/plugins/ssu_catch.rs
+++ b/src/plugins/ssu_catch.rs
@@ -59,12 +59,12 @@ impl SsuCatchPlugin {
 
         let response = reqwest::get(page_url)
             .await
-            .map_err(|e| PluginError::request(Self::IDENTIFIER, e.to_string()))?;
+            .map_err(|e| PluginError::request::<Self>(e.to_string()))?;
 
         let html = response
             .text()
             .await
-            .map_err(|e| PluginError::parse(Self::IDENTIFIER, e.to_string()))?;
+            .map_err(|e| PluginError::parse::<Self>(e.to_string()))?;
 
         let document = Html::parse_document(&html);
 
@@ -135,12 +135,12 @@ impl SsuCatchPlugin {
     ) -> Result<String, PluginError> {
         let response = reqwest::get(post_url)
             .await
-            .map_err(|e| PluginError::request(Self::IDENTIFIER, e.to_string()))?;
+            .map_err(|e| PluginError::request::<Self>(e.to_string()))?;
 
         let html = response
             .text()
             .await
-            .map_err(|e| PluginError::parse(Self::IDENTIFIER, e.to_string()))?;
+            .map_err(|e| PluginError::parse::<Self>(e.to_string()))?;
 
         let document = Html::parse_document(&html);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

Resolves #26 

## 📝작업 내용

- `SsufidError`를 `Error`로 rename
- `Error`, `SsufidCore`를 re-export
- `Error`의 variant 재정비, `Plugin` variant 추가
- `PluginError`에 `PluginErrorKind`를 통한 구조화

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
