### PR TITLE
[refactor] SsuCatchPlugin 구조체의 필드로 CSS 선택자를 관리하도록 수정

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> eyre::Result<()> {
 
     let out_dir = Path::new("./out");
 
-    let tasks = vec![save_run(core.clone(), out_dir, SsuCatchPlugin)];
+    let tasks = vec![save_run(core.clone(), out_dir, SsuCatchPlugin::default())];
 
     join_all(tasks).await.into_iter().for_each(|result| {
         if let Err(err) = result {


### PR DESCRIPTION
## #️⃣연관된 이슈

resolved #32 

## 📝작업 내용
- `SsuCatchPlugin` 구조체의 `selctors` 필드로 CSS 선택자를 관리하도록 수정했습니다.
- `SsuCatchPlugin` 메서드에서는 `self.selectors`로 필요한 CSS 선택자를 참조할 수 있습니다.

## 💬리뷰 요구사항(선택)

- `SsuCatchPlugin` 구조체에 `new()` 연관함수만 추가하려 했는데 Clippy의 [new_without_default](https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default) 규칙 때문에 Default 트레이트도 구현했습니다.
