### PR TITLE
[fix] posts_limit까지 페이지가 아닌 포스트를 가져오도록 수정

### DIFF
--- a/src/plugins/ssu_catch.rs
+++ b/src/plugins/ssu_catch.rs
@@ -197,11 +197,17 @@ impl SsufidPlugin for SsuCatchPlugin {
 
     async fn crawl(&self, posts_limit: u32) -> Result<Vec<SsufidPost>, PluginError> {
         let mut all_posts = Vec::new();
+        let mut page = 1;
 
-        for page in 1..=posts_limit {
+        while all_posts.len() < posts_limit as usize {
             let metadata_items = self.fetch_page_posts(page).await?;
 
             for metadata in metadata_items {
+                // posts_limit에 도달했는지 확인
+                if all_posts.len() >= posts_limit as usize {
+                    break;
+                }
+
                 let content = self.fetch_post_content(&metadata.url).await?;
 
                 let post = SsufidPost {
@@ -216,6 +222,8 @@ impl SsufidPlugin for SsuCatchPlugin {
 
                 all_posts.push(post);
             }
+
+            page += 1;
         }
 
         for post in &all_posts {


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #30 

## 📝작업 내용

- `POST_COUNT_LIMIT` 개수만큼 페이지가 아닌 포스트를 크롤링하도록 수정했습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
