### PR TITLE
feat: SSU Catch 공지사항을 병렬적으로 크롤링하는 기능 구현

### DIFF
--- a/src/plugins/ssu_catch.rs
+++ b/src/plugins/ssu_catch.rs
@@ -56,6 +56,7 @@ impl Default for SsuCatchPlugin {
 
 impl SsuCatchPlugin {
     const BASE_URL: &'static str = "https://scatch.ssu.ac.kr/%ea%b3%b5%ec%a7%80%ec%82%ac%ed%95%ad";
+    const POSTS_PER_PAGE: u32 = 15; // 페이지당 게시글 수
 
     pub fn new() -> Self {
         Self {
@@ -196,38 +197,53 @@ impl SsufidPlugin for SsuCatchPlugin {
     const DESCRIPTION: &'static str = "숭실대학교 공식 홈페이지의 공지사항을 제공합니다.";
 
     async fn crawl(&self, posts_limit: u32) -> Result<Vec<SsufidPost>, PluginError> {
-        let mut all_posts = Vec::new();
-        let mut page = 1;
+        let pages = posts_limit / Self::POSTS_PER_PAGE + 1;
+        let mut page_futures = Vec::new();
 
-        while all_posts.len() < posts_limit as usize {
-            let metadata_items = self.fetch_page_posts(page).await?;
-
-            for metadata in metadata_items {
-                // posts_limit에 도달했는지 확인
-                if all_posts.len() >= posts_limit as usize {
-                    break;
-                }
-
-                let content = self.fetch_post_content(&metadata.url).await?;
-
-                let post = SsufidPost {
-                    id: metadata.id,
-                    title: metadata.title,
-                    category: metadata.category,
-                    url: metadata.url,
-                    created_at: metadata.created_at,
-                    updated_at: None,
-                    content,
-                };
-
-                all_posts.push(post);
-            }
-
-            page += 1;
+        for page in 1..=pages {
+            page_futures.push(self.fetch_page_posts(page));
         }
 
-        for post in &all_posts {
-            println!("{:?}", post);
+        // 모든 페이지 크롤링이 완료될 때까지 대기
+        let page_results = futures::future::join_all(page_futures).await;
+        let mut all_metadata = Vec::new();
+
+        for page_result in page_results {
+            let metadata_items = page_result?;
+            for metadata in metadata_items {
+                all_metadata.push(metadata);
+                // posts_limit에 도달하면 더 이상 메타데이터 추가하지 않음
+                if all_metadata.len() >= posts_limit as usize {
+                    break;
+                }
+            }
+        }
+
+        let mut content_futures = Vec::new();
+
+        for metadata in &all_metadata {
+            content_futures.push(self.fetch_post_content(&metadata.url));
+        }
+
+        // 모든 포스트 크롤링이 완료될 때까지 대기
+        let contents = futures::future::join_all(content_futures).await;
+        let mut all_posts = Vec::new();
+
+        for (i, content_result) in contents.into_iter().enumerate() {
+            let metadata = &all_metadata[i];
+            let content = content_result?;
+
+            let post = SsufidPost {
+                id: metadata.id.clone(),
+                title: metadata.title.clone(),
+                category: metadata.category.clone(),
+                url: metadata.url.clone(),
+                created_at: metadata.created_at,
+                updated_at: None,
+                content,
+            };
+
+            all_posts.push(post);
         }
 
         Ok(all_posts)


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #31 

## 📝작업 내용

- [future::join_all()](https://docs.rs/futures/latest/futures/future/fn.join_all.html) 함수를 사용해 SSU Catch 공지사항을 병렬적으로 크롤링 하는 기능을 구현했습니다.

## 💬리뷰 요구사항(선택)

- 한 페이지에 15개의 게시글이 있다는 가정하에 동작하는 코드라 페이지에 게시글이 15개 미만으로 있을 경우(예) [SSU Catch 마지막 페이지](https://scatch.ssu.ac.kr/%EA%B3%B5%EC%A7%80%EC%82%AC%ED%95%AD/page/739/)의 경우 게시글이 15개 미만임) `posts_limit`만큼 게시글을 크롤링하지 못할 것 같은데 어떻게 개선할 수 있을지 고민이 됩니다.