### PR TITLE
[fix] Vec에서 `title`과 `category`를 안전하게 가져오도록 수정

### DIFF
--- a/src/plugins/ssu_catch.rs
+++ b/src/plugins/ssu_catch.rs
@@ -122,8 +122,14 @@ impl SsuCatchPlugin {
                     .map(|span| span.text().collect::<String>())
                     .collect::<Vec<String>>();
 
-                let category = spans[0].clone();
-                let title = spans[1].clone();
+                let category = spans
+                    .first()
+                    .map(|s| s.to_string())
+                    .unwrap_or("".to_string());
+                let title = spans
+                    .get(1)
+                    .map(|s| s.to_string())
+                    .unwrap_or("".to_string());
 
                 SsuCatchMetadata {
                     id,


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #56 

## 📝작업 내용
- `title`이나 `category` 정보가 없는 span 요소를 파싱할 때 Vec의 길이가 달라지는 문제가 있어 Vec의 `get()`과 `unwrap_or()` 메서드를 사용하여 `title`과 `category`를 안전하게 가져오도록 수정하였습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
