### PR TITLE
플러그인 크롤링 시도 횟수 설정 및 main 함수 비정상 종료 로직 추가

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -73,7 +73,13 @@ impl SsufidCore {
                     break posts;
                 }
                 Err(e) => {
-                    eprintln!("{} attempt: {} - {:?}", T::IDENTIFIER, crawl_attempt, e);
+                    eprintln!(
+                        "[Plugin {}] Attempt: {}/{} - {:?}",
+                        T::IDENTIFIER,
+                        crawl_attempt,
+                        SsufidCore::CRAWL_ATTEMPT_LIMIT,
+                        e
+                    );
                     if crawl_attempt >= SsufidCore::CRAWL_ATTEMPT_LIMIT {
                         return Err(e.into());
                     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -74,11 +74,10 @@ impl SsufidCore {
                 }
                 Err(e) => {
                     eprintln!(
-                        "[Plugin {}] Attempt: {}/{} - {:?}",
-                        T::IDENTIFIER,
+                        "{:?} [Attempt {}/{}]",
+                        e,
                         crawl_attempt,
                         SsufidCore::CRAWL_ATTEMPT_LIMIT,
-                        e
                     );
                     if crawl_attempt >= SsufidCore::CRAWL_ATTEMPT_LIMIT {
                         return Err(e.into());

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -51,7 +51,7 @@ pub struct SsufidCore {
 
 impl SsufidCore {
     pub const POST_COUNT_LIMIT: u32 = 100;
-    const ATTEMPT_LIMIT: u32 = 3;
+    const CRAWL_ATTEMPT_LIMIT: u32 = 3;
 
     pub fn new(cache_dir: &str) -> Self {
         Self {
@@ -65,16 +65,16 @@ impl SsufidCore {
         plugin: T,
         posts_limit: u32,
     ) -> Result<SsufidSiteData, Error> {
-        let mut attempt = 0;
+        let mut crawl_attempt = 0;
         let new_entries = loop {
-            attempt += 1;
+            crawl_attempt += 1;
             match plugin.crawl(posts_limit).await {
                 Ok(posts) => {
                     break posts;
                 }
                 Err(e) => {
-                    eprintln!("{} attempt: {} - {:?}", T::IDENTIFIER, attempt, e);
-                    if attempt >= SsufidCore::ATTEMPT_LIMIT {
+                    eprintln!("{} attempt: {} - {:?}", T::IDENTIFIER, crawl_attempt, e);
+                    if crawl_attempt >= SsufidCore::CRAWL_ATTEMPT_LIMIT {
                         return Err(e.into());
                     }
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,9 @@ pub enum Error {
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    #[error("Attempts exceeded error: {0}")]
+    AttemptsExceeded(&'static str),
+
     #[error(transparent)]
     Plugin(Box<PluginError>),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::{io::BufWriter, path::Path, sync::Arc};
 
-use eyre::Ok;
 use futures::future::join_all;
 use ssufid::{
     core::{SsufidCore, SsufidPlugin},

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,13 @@ async fn save_run<T: SsufidPlugin>(
     base_out_dir: &Path,
     plugin: T,
 ) -> eyre::Result<()> {
-    let site = core.run(plugin, SsufidCore::POST_COUNT_LIMIT).await?;
+    let site = core
+        .run_with_retry(
+            &plugin,
+            SsufidCore::POST_COUNT_LIMIT,
+            SsufidCore::RETRY_COUNT,
+        )
+        .await?;
     let json = serde_json::to_string_pretty(&site)?;
 
     // Use synchronous BufWriter to write pretty xml string.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,14 +17,22 @@ async fn main() -> eyre::Result<()> {
 
     let tasks = vec![save_run(core.clone(), out_dir, SsuCatchPlugin::default())];
 
+    let mut is_successful = false;
     join_all(tasks).await.into_iter().for_each(|result| {
         if let Err(err) = result {
             eprintln!("{:?}", err);
+        } else {
+            is_successful = true;
         }
     });
 
     core.save_cache().await?;
-    Ok(())
+
+    if is_successful {
+        Ok(())
+    } else {
+        panic!("all plugin failed")
+    }
 }
 
 async fn save_run<T: SsufidPlugin>(


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves #49 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- crawl의 최대 시도 횟수를 3번으로 설정했습니다.
- main 함수에서 모든 플러그인 실패 시 `panic!`을 수행하도록 했습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- crawl 실패시 에러 메시지를 `eprintln!("{} attempt: {} - {:?}", T::IDENTIFIER, crawl_attempt, e);`으로 했는데 메시지를 조금 더 좋게 할 수 있을까요?
- main 함수에서 직접 `panic!`을 호출하도록 하는 것보다 더 좋은 방법이 있을까요?