### PR TITLE
[feat] SSU Catch 플러그인의 크롤링 진행상황 로깅

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +417,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -954,6 +986,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1331,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,6 +1414,35 @@ checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -1670,8 +1770,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "color-eyre",
+ "env_logger",
  "eyre",
  "futures",
+ "log",
  "reqwest",
  "rss",
  "scraper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ url = "2.5.4"
 futures = "0.3.31"
 color-eyre = "0.6.3"
 clap = { version = "4.5.35", features = ["derive"] }
+log = "0.4.27"
+env_logger = "0.11.8"
 
 [dev-dependencies]
 time = { version = "0.3.40", features = ["macros"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, io::BufWriter, ops::Not, path::Path, sync::Arc};
 
 use clap::Parser;
+use env_logger::{Builder, Env};
 use futures::future::join_all;
 use ssufid::{
     core::{SsufidCore, SsufidPlugin},
@@ -42,6 +43,8 @@ struct SsufidDaemonOptions {
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    Builder::from_env(Env::default().filter_or("RUST_LOG", "info")).init();
+
     color_eyre::install()?;
     let options = SsufidDaemonOptions::parse();
 

--- a/src/plugins/ssu_catch.rs
+++ b/src/plugins/ssu_catch.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use log::info;
+use log::{info, warn};
 use scraper::{Html, Selector};
 use url::Url;
 
@@ -85,7 +85,7 @@ impl SsuCatchPlugin {
         let posts = notice_list
             .select(&self.selectors.li)
             .skip(1)
-            .map(|li| {
+            .filter_map(|li| {
                 let date_format = format_description::parse("[year].[month].[day]").unwrap();
                 let date_string = li
                     .select(&self.selectors.date)
@@ -126,13 +126,18 @@ impl SsuCatchPlugin {
                     .map(|element| element.text().collect::<String>())
                     .unwrap_or_default();
 
-                SsuCatchMetadata {
+                if id.is_empty() {
+                    warn!("ID is empty for post: {}", title);
+                    return None;
+                }
+
+                Some(SsuCatchMetadata {
                     id,
                     title,
                     category,
                     url,
                     created_at: offset_datetime,
-                }
+                })
             })
             .collect();
 
@@ -202,7 +207,7 @@ impl SsufidPlugin for SsuCatchPlugin {
         // 모든 페이지 크롤링이 완료될 때까지 대기
         let metadata_results = futures::future::join_all((1..=pages).map(|page| {
             let result = self.fetch_page_posts(page);
-            info!("포스트 메타데이터 크롤링 중: {}/{}", page, pages);
+            info!("Crawling post metadata from page: {}/{}", page, pages);
             result
         }))
         .await;
@@ -218,7 +223,7 @@ impl SsufidPlugin for SsuCatchPlugin {
         // 모든 포스트 크롤링이 완료될 때까지 대기
         let content_results = futures::future::join_all(all_metadata.iter().map(|metadata| {
             let result = self.fetch_post_content(&metadata.url);
-            info!("포스트 컨텐츠 크롤링 중: {}", metadata.id);
+            info!("Crawling post content from post: {}", metadata.title);
             result
         }))
         .await;


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #54 

## 📝작업 내용
<img width="801" alt="image" src="https://github.com/user-attachments/assets/ef9fee1a-e735-45a1-b7dc-a9386c65289d" />

- [env_logger](https://docs.rs/env_logger/latest/env_logger/index.html)로 SSU Catch 플러그인의 크롤링 진행상황을 로깅하는 기능을 추가하였습니다.
- 게시글의 `id`가 비어있을 경우(게시글 URL의 `slug` 파라미터의 값이 없는 경우) warning 로그를 출력하고 해당 게시글은 크롤링 결과에 포함되지 않도록 하였습니다.
- 로그는 아래 6가지 레벨로 구분되며 기본적으로 `info` 레벨 이상의 로그들은 모두 출력되도록 하였습니다.
  - error
  - warn
  - info
  - debug
  - trace
  - off (pseudo level to disable all logging for the target) 
- `cargo run` 명령어로 프로그램을 실행할 때 `RUST_LOG` 환경변수를 추가하여 출력되는 로그의 레벨을 조정할 수 있습니다.
```bash
RUST_LOG=warn cargo run # warn 레벨 이상의 로그들만 출력
```

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
