### PR TITLE
[fix] 공지사항 내용의 줄바꿈이 유지되도록 수정

### DIFF
--- a/src/plugins/ssu_catch.rs
+++ b/src/plugins/ssu_catch.rs
@@ -168,7 +168,7 @@ impl SsuCatchPlugin {
             .map(|line| line.trim())
             .filter(|line| !line.is_empty())
             .collect::<Vec<&str>>()
-            .join(" ");
+            .join("\n");
 
         Ok(content)
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #70 

## 📝작업 내용

- 공지사항 내용의 줄바꿈이 유지되도록 수정했습니다.
- 수정된 `content` 필드 예시
```
"2025-1학기 외국인등록증 지문등록 안내\n2025학년도 1학기 외국인 단체접수를 완료한 신규 유학생을 대상으로 외국인등록증 지문등록 일정을 다음과 같이 안내드립니다.\n1. 대상 : 2025-1 신/편입 유학생 (학부, 대학원, 교환/방문학생, 어학연수생)\n2. 일시: 2025.04.14.(월) 14:00~17:00\n3. 장소: 숭실대학교 전산관\n– 대기실: 전산관 509호\n– 지문등록: 전산관 508호\n4. 준비물: 실물 여권\n* 반드시 실물 여권으로 지참, 복사본 또는 휴대폰 사진파일 불가\n5. 유의사항\n가. 지문등록을 하지 않을 경우 직접 출입국사무소를 방문해야 하며, 미등록시 체류에 불이익이 있을 수 있습니다.\n나. 지문등록 대상자가 많아 혼잡이 예상되오니, 가급적이면 미리 도착하여 대기해 주시고, 원활한 진행을 위해 늦어도 16시 30분까지 도착해 주시기 바랍니다.\n6. 문의: 국제처 유학생관리·지원팀 (신양관 203호)\n– 전화: 02-820-0788 / 02-828-7355~6\n– 이메일: undergrad@ssu.ac.kr\n– 카카오플러스친구 1:1채팅: http://pf.kakao.com/_Cbayj/chat\n2025.04.09.\n국제처장"
```

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
