### PR TITLE
[test/fix] test_read_cache에서 테스트 파일 flush

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -222,6 +222,7 @@ mod tests {
         tokio::fs::create_dir_all(dir).await.unwrap();
         let mut test_file = tokio::fs::File::create(&test_file_path).await.unwrap();
         test_file.write_all(mock_json.as_bytes()).await.unwrap();
+        test_file.flush().await.unwrap();
 
         // read file
         let core = SsufidCore::new("./cache_test");


### PR DESCRIPTION
## #️⃣연관된 이슈

테스트 수행 도중 `read_cache`에서 flush되지 않은 파일을 읽어 빈 문자열 파싱을 시도하여 테스트가 실패하는 문제 발생

- https://github.com/yourssu/ssufid/actions/runs/14333536949/job/40174853536

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- test_file flush

## 💬리뷰 요구사항(선택)
X
