### PR TITLE
[feat] 플러그인 수행 시간 로깅

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -82,15 +82,16 @@ impl SsufidCore {
                 .await
                 .inspect_err(|e| error!("{:?} [Attempt {}/{}]", e, attempt, retry_count));
 
-            let elapsed = start.elapsed();
+            if let Ok(data) = &result {
+                let elapsed = start.elapsed();
 
-            info!(
-                "[{}] completed crawling in {:.2}s",
-                T::IDENTIFIER,
-                elapsed.as_secs_f32()
-            );
+                info!(
+                    "[{}] Successfully crawled {} posts in {:.2}s",
+                    T::IDENTIFIER,
+                    data.items.len(),
+                    elapsed.as_secs_f32()
+                );
 
-            if result.is_ok() {
                 return result;
             }
         }

--- a/src/plugins/ssu_catch.rs
+++ b/src/plugins/ssu_catch.rs
@@ -113,7 +113,7 @@ impl SsuCatchPlugin {
                     .to_string();
 
                 if id.is_empty() {
-                    warn!("ID is empty for URL: {}", url);
+                    warn!("[{}] ID is empty for URL: {}", Self::IDENTIFIER, url);
                     return None;
                 }
 
@@ -248,7 +248,12 @@ impl SsufidPlugin for SsuCatchPlugin {
 
         // 모든 페이지 크롤링이 완료될 때까지 대기
         let metadata_results = futures::future::join_all((1..=pages).map(|page| {
-            info!("Crawling post metadata from page: {}/{}", page, pages);
+            info!(
+                "[{}] Crawling post metadata from page: {}/{}",
+                Self::IDENTIFIER,
+                page,
+                pages
+            );
             self.fetch_page_posts_metadata(page)
         }))
         .await;
@@ -262,10 +267,11 @@ impl SsufidPlugin for SsuCatchPlugin {
             .collect::<Vec<SsuCatchMetadata>>();
 
         // 모든 포스트 크롤링이 완료될 때까지 대기
-        let post_results = futures::future::join_all(all_metadata.iter().map(|metadata| {
-            info!("Crawling post content for ID: {}", metadata.id);
-            self.fetch_post(metadata)
-        }))
+        let post_results = futures::future::join_all(
+            all_metadata
+                .iter()
+                .map(|metadata| self.fetch_post(metadata)),
+        )
         .await;
 
         let all_posts = post_results


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolved #50 

## 📝작업 내용
<img width="796" alt="image" src="https://github.com/user-attachments/assets/a9b7152f-4a27-46f6-ad65-bf6d15dc5174" />

- 플러그인의 수행 시간을 로깅하는 기능을 추가했습니다.
- 어떤 플러그인에서 로깅한지 알 수 있도록 로깅 메시지에 SSU Catch 플러그인 태그를 추가했습니다.
- ~일관적인 로깅을 위해 `eprintln!()`을 `log::error!()`로 수정했습니다.~ -> [8ab77c](https://github.com/yourssu/ssufid/pull/82/commits/8ab77cf11d1f3160949febd2e8921dcf6042c2d0)에서 수정됨

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
