### PR TITLE
[feat] SsufidPost의 정의 업데이트

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +1784,7 @@ dependencies = [
  "eyre",
  "futures",
  "log",
+ "mime_guess",
  "reqwest",
  "rss",
  "scraper",
@@ -2110,6 +2121,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ color-eyre = "0.6.3"
 clap = { version = "4.5.35", features = ["derive"] }
 log = "0.4.27"
 env_logger = "0.11.8"
+mime_guess = "2.0.5"
 
 [dev-dependencies]
 time = { version = "0.3.40", features = ["macros"] }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 use serde::{Deserialize, Serialize};
 use time;
@@ -8,23 +11,30 @@ use tokio::sync::RwLock;
 use crate::error::{Error, PluginError};
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct Attachment {
+    pub url: String,
+    pub name: Option<String>,
+    pub mime_type: Option<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct SsufidPost {
     pub id: String,
     pub url: String,
-    #[serde(default)]
-    pub author: String,
+    pub author: Option<String>,
     pub title: String,
+    pub description: Option<String>,
     #[serde(default)]
     pub category: Vec<String>,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: time::OffsetDateTime,
     #[serde(with = "time::serde::rfc3339::option")]
     pub updated_at: Option<time::OffsetDateTime>,
-    #[serde(default)]
-    pub thumbnail: String,
+    pub thumbnail: Option<String>,
     pub content: String,
     #[serde(default)]
-    pub attachments: Vec<String>,
+    pub attachments: Vec<Attachment>,
+    pub metadata: Option<BTreeMap<String, String>>,
 }
 
 impl SsufidPost {
@@ -205,28 +215,41 @@ mod tests {
     async fn test_read_cache() {
         let mock = vec![
             SsufidPost {
-                id: "test-id".to_string(),
-                url: "https://example.com/test".to_string(),
-                author: "Test Author".to_string(),
-                title: "Test Title".to_string(),
-                category: vec!["Test Category".to_string()],
+                id: "test-id-1".to_string(),
+                url: "https://example.com/test1".to_string(),
+                author: Some("Author One".to_string()),
+                title: "Test Title 1".to_string(),
+                description: Some("This is a description for test 1.".to_string()),
+                category: vec!["Category A".to_string()],
                 created_at: datetime!(2024-03-22 12:00:00 UTC),
                 updated_at: None,
-                thumbnail: "https://example.com/thumbnail.jpg".to_string(),
-                content: "Test Content".to_string(),
-                attachments: vec![],
+                thumbnail: Some("https://example.com/thumb1.jpg".to_string()),
+                content: "Test Content 1".to_string(),
+                attachments: vec![super::Attachment {
+                    url: "https://example.com/attachment1.pdf".to_string(),
+                    name: Some("Attachment 1".to_string()),
+                    mime_type: Some("application/pdf".to_string()),
+                }],
+                metadata: Some(
+                    [("key1".to_string(), "value1".to_string())]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
             },
             SsufidPost {
-                id: "test-id".to_string(),
-                url: "https://example.com/test".to_string(),
-                author: "Test Author".to_string(),
-                title: "Test Title".to_string(),
-                category: vec!["Test Category".to_string()],
-                created_at: datetime!(2024-03-22 12:00:00 UTC),
-                updated_at: Some(datetime!(2024-03-22 12:00:00 UTC)),
-                thumbnail: "https://example.com/thumbnail.jpg".to_string(),
-                content: "Test Content".to_string(),
-                attachments: vec![],
+                id: "test-id-2".to_string(),
+                url: "https://example.com/test2".to_string(),
+                author: None, // Test None author
+                title: "Test Title 2".to_string(),
+                description: None, // Test None description
+                category: vec!["Category B".to_string(), "Category C".to_string()],
+                created_at: datetime!(2024-03-23 10:00:00 UTC),
+                updated_at: Some(datetime!(2024-03-23 11:00:00 UTC)),
+                thumbnail: None, // Test None thumbnail
+                content: "Test Content 2".to_string(),
+                attachments: vec![], // Test empty attachments
+                metadata: None,      // Test None metadata
             },
         ];
 
@@ -262,26 +285,39 @@ mod tests {
             SsufidPost {
                 id: "1".to_string(),
                 url: "http://example.com/1".to_string(),
-                author: "Old Author".to_string(),
+                author: Some("Author 1".to_string()),
                 title: "Old Title 1".to_string(),
+                description: Some("Description for 1".to_string()),
                 category: vec!["Category 1".to_string()],
                 created_at: now,
                 updated_at: None,
-                thumbnail: "http://example.com/thumbnail1.jpg".to_string(),
+                thumbnail: Some("http://example.com/thumb1.jpg".to_string()),
                 content: "Old Content 1".to_string(),
-                attachments: vec![],
+                attachments: vec![super::Attachment {
+                    url: "http://example.com/attach1.doc".to_string(),
+                    name: None,
+                    mime_type: None,
+                }],
+                metadata: Some(
+                    [("meta_key_1".to_string(), "meta_value_1".to_string())]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
             },
             SsufidPost {
                 id: "2".to_string(),
                 url: "http://example.com/2".to_string(),
-                author: "Old Author".to_string(),
+                author: Some("Author 2".to_string()),
                 title: "Old Title 2".to_string(),
+                description: Some("Description for 2".to_string()),
                 category: vec!["Category 2".to_string()],
                 created_at: now,
-                updated_at: Some(now),
-                thumbnail: "http://example.com/thumbnail2.jpg".to_string(),
+                updated_at: Some(now), // Pre-existing update time
+                thumbnail: Some("http://example.com/thumb2.jpg".to_string()),
                 content: "Old Content 2".to_string(),
                 attachments: vec![],
+                metadata: None,
             },
         ];
 
@@ -290,53 +326,83 @@ mod tests {
             SsufidPost {
                 id: "1".to_string(),
                 url: "http://example.com/1".to_string(),
-                author: "Old Author".to_string(),
-                title: "Old Title 1".to_string(),
-                category: vec!["Category 1".to_string()],
+                author: Some("Author 1".to_string()), // Same as old
+                title: "Old Title 1".to_string(),     // Same as old
+                description: Some("Description for 1".to_string()), // Same as old
+                category: vec!["Category 1".to_string()], // Same as old
                 created_at: now,
                 updated_at: None,
-                thumbnail: "http://example.com/thumbnail1.jpg".to_string(),
-                content: "Old Content 1".to_string(),
-                attachments: vec![],
+                thumbnail: Some("http://example.com/thumb1.jpg".to_string()), // Same as old
+                content: "Old Content 1".to_string(),                         // Same as old
+                attachments: vec![super::Attachment {
+                    // Same as old
+                    url: "http://example.com/attach1.doc".to_string(),
+                    name: None,
+                    mime_type: None,
+                }],
+                metadata: Some(
+                    // Same as old
+                    [("meta_key_1".to_string(), "meta_value_1".to_string())]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
             },
-            // Case 2: 기존 포스트와 내용이 다른 경우
+            // Case 2: 기존 포스트와 내용(title)이 다른 경우 -> updated_at 설정됨
             SsufidPost {
                 id: "2".to_string(),
-                url: "http://example.com/2".to_string(),
-                author: "Old Author".to_string(),
-                title: "Updated Title 2".to_string(), // 제목 변경
-                category: vec!["Category 2".to_string()],
+                url: "http://example.com/2_new".to_string(), // URL 변경 (contents_eq에 영향 없음)
+                author: Some("Author 2 Updated".to_string()), // Author 변경 (contents_eq에 영향 없음)
+                title: "Updated Title 2".to_string(), // 제목 변경 (contents_eq에 영향 있음!)
+                description: Some("Description for 2 Updated".to_string()), // Description 변경 (contents_eq에 영향 없음)
+                category: vec!["Category 2".to_string()],                   // Same
                 created_at: now,
-                updated_at: None,
-                thumbnail: "http://example.com/thumbnail2.jpg".to_string(),
-                content: "Old Content 2".to_string(),
-                attachments: vec![],
+                updated_at: None, // Should be set by inject_update_date
+                thumbnail: Some("http://example.com/thumb2_new.jpg".to_string()), // Thumbnail 변경 (contents_eq에 영향 없음)
+                content: "Old Content 2".to_string(),                             // Same
+                attachments: vec![super::Attachment {
+                    // Attachment 추가 (contents_eq에 영향 없음)
+                    url: "http://example.com/attach2.png".to_string(),
+                    name: Some("New Attachment".to_string()),
+                    mime_type: Some("image/png".to_string()),
+                }],
+                metadata: Some(
+                    // Metadata 추가 (contents_eq에 영향 없음)
+                    [("meta_key_2".to_string(), "meta_value_2".to_string())]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                ),
             },
-            // Case 3: 새로운 포스트인 경우
+            // Case 3: 새로운 포스트인 경우 -> updated_at 설정 안됨
             SsufidPost {
                 id: "3".to_string(),
                 url: "http://example.com/3".to_string(),
-                author: "New Author".to_string(),
+                author: Some("New Author 3".to_string()),
                 title: "New Title 3".to_string(),
+                description: Some("Description for 3".to_string()),
                 category: vec!["Category 3".to_string()],
                 created_at: now,
-                updated_at: None,
-                thumbnail: "http://example.com/thumbnail3.jpg".to_string(),
+                updated_at: None, // Should remain None
+                thumbnail: None,
                 content: "New Content 3".to_string(),
                 attachments: vec![],
+                metadata: None,
             },
-            // Case 4: 이미 updated_at이 설정된 경우
+            // Case 4: 이미 updated_at이 설정된 경우 -> 기존 updated_at 유지
             SsufidPost {
                 id: "4".to_string(),
                 url: "http://example.com/4".to_string(),
-                author: "Old Author".to_string(),
+                author: Some("Author 4".to_string()),
                 title: "Title 4".to_string(),
+                description: Some("Description for 4".to_string()),
                 category: vec!["Category 4".to_string()],
                 created_at: now,
-                updated_at: Some(now),
-                thumbnail: "http://example.com/thumbnail4.jpg".to_string(),
+                updated_at: Some(now), // Pre-set update time, should be kept
+                thumbnail: Some("http://example.com/thumb4.jpg".to_string()),
                 content: "Content 4".to_string(),
                 attachments: vec![],
+                metadata: None,
             },
         ];
 

--- a/src/core/rss.rs
+++ b/src/core/rss.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use rss::{
-    ChannelBuilder, ItemBuilder,
+    Category, ChannelBuilder, Enclosure, ItemBuilder,
     extension::{Extension, ExtensionBuilder},
 };
 use time::format_description::well_known::{Rfc2822, Rfc3339};
@@ -14,10 +14,12 @@ impl From<SsufidPost> for rss::Item {
     fn from(post: SsufidPost) -> Self {
         let mut builder = ItemBuilder::default();
 
-        let description = post.content.char_indices().nth(50).map_or_else(
-            || post.content.clone(),
-            |(i, _)| format!("{}...", &post.content[..i]),
-        );
+        let description = post.description.clone().unwrap_or_else(|| {
+            post.content.char_indices().nth(50).map_or_else(
+                || post.content.clone(),
+                |(i, _)| format!("{}...", &post.content[..i]),
+            )
+        });
 
         builder
             .title(post.title)
@@ -29,6 +31,34 @@ impl From<SsufidPost> for rss::Item {
             })
             .description(description)
             .content(post.content);
+
+        if let Some(author) = post.author {
+            builder.author(author);
+        }
+
+        if !post.category.is_empty() {
+            builder.categories(
+                post.category
+                    .into_iter()
+                    .map(|c| Category {
+                        name: c,
+                        domain: None,
+                    })
+                    .collect::<Vec<Category>>(),
+            );
+        }
+
+        if let Some(thumbnail_url) = post.thumbnail {
+            builder.enclosure(Enclosure {
+                url: thumbnail_url,
+                length: "0".to_string(),          // Length is often unknown
+                mime_type: "image/*".to_string(), // Generic image type
+            });
+        }
+        // TODO: use media extension to iterate over attachments
+        // for attachment in post.attachments {
+        // }
+
         if let Some(updated_at) = post.updated_at {
             let extension = ExtensionBuilder::default()
                 .name("atom:updated")
@@ -71,76 +101,209 @@ mod tests {
     use time::macros::datetime;
 
     use super::*;
+    use crate::core::Attachment; // Import Attachment
 
     #[test]
-    fn test_ssufid_post_to_rss_item() {
+    fn test_ssufid_post_to_rss_item_basic() {
         let post = SsufidPost {
-            id: "test-id".to_string(),
-            url: "https://example.com/test".to_string(),
-            author: "Test Author".to_string(),
-            title: "Test Title".to_string(),
-            category: vec!["Test Category".to_string()],
+            id: "test-id-basic".to_string(),
+            url: "https://example.com/basic".to_string(),
+            author: Some("Basic Author".to_string()),
+            title: "Basic Title".to_string(),
+            description: None, // Description is None, should fallback to content
+            category: vec!["Basic Category".to_string()],
             created_at: datetime!(2024-03-22 12:00:00 UTC),
             updated_at: Some(datetime!(2024-03-27 12:00:00 UTC)),
-            thumbnail: "https://example.com/thumbnail.jpg".to_string(),
-            content: "Test Content".to_string(),
-            attachments: vec![],
+            thumbnail: Some("https://example.com/basic_thumb.jpg".to_string()),
+            content: "Basic Content".to_string(),
+            attachments: vec![], // No attachments
+            metadata: None,
         };
 
         let rss_item: rss::Item = post.into();
 
-        assert_eq!(rss_item.title(), Some("Test Title"));
-        assert_eq!(rss_item.link(), Some("https://example.com/test"));
+        assert_eq!(rss_item.title(), Some("Basic Title"));
+        assert_eq!(rss_item.link(), Some("https://example.com/basic"));
         assert_eq!(rss_item.pub_date(), Some("Fri, 22 Mar 2024 12:00:00 +0000"));
-        assert_eq!(rss_item.guid().unwrap().value(), "test-id");
+        assert_eq!(rss_item.guid().unwrap().value(), "test-id-basic");
         assert!(!rss_item.guid().unwrap().is_permalink());
         assert_eq!(
             rss_item
                 .extensions()
-                .get("http://www.w3.org/2005/Atom")
+                .get(ATOM_NAMESPACE)
                 .and_then(|m| m.get("atom:updated"))
                 .and_then(|v| v.first())
                 .and_then(|e| e.value()),
             Some("2024-03-27T12:00:00Z")
         );
-        assert_eq!(rss_item.content(), Some("Test Content"));
+        assert_eq!(rss_item.content(), Some("Basic Content"));
+        // Check description (should use content if description is None)
+        assert_eq!(rss_item.description(), Some("Basic Content"));
+        // Check author
+        assert_eq!(rss_item.author(), Some("Basic Author"));
+        // Check categories
+        assert_eq!(rss_item.categories().len(), 1);
+        assert_eq!(rss_item.categories()[0].name(), "Basic Category");
+        // Check enclosure (thumbnail)
+        let enclosure = rss_item.enclosure();
+        assert!(enclosure.is_some()); // Only thumbnail
+        assert_eq!(
+            enclosure.unwrap().url(),
+            "https://example.com/basic_thumb.jpg"
+        );
+        assert_eq!(enclosure.unwrap().mime_type(), "image/*");
+    }
+
+    #[test]
+    fn test_ssufid_post_to_rss_item_full() {
+        let post = SsufidPost {
+            id: "test-id-full".to_string(),
+            url: "https://example.com/full".to_string(),
+            author: None, // Test None author
+            title: "Full Title".to_string(),
+            description: Some("This is a specific description.".to_string()), // Specific description
+            category: vec!["Category A".to_string(), "Category B".to_string()],
+            created_at: datetime!(2024-03-23 10:00:00 UTC),
+            updated_at: None, // Test None updated_at
+            thumbnail: None,  // Test None thumbnail
+            content: "This is a longer content that should not be used for the description."
+                .to_string(),
+            attachments: vec![
+                Attachment {
+                    url: "https://example.com/attachment1.pdf".to_string(),
+                    name: Some("Document 1".to_string()), // Name is not used in RSS enclosure
+                    mime_type: Some("application/pdf".to_string()),
+                },
+                Attachment {
+                    url: "https://example.com/attachment2.zip".to_string(),
+                    name: None,
+                    mime_type: None, // Test None mime_type, should default
+                },
+            ],
+            metadata: Some(
+                // Metadata is not used in RSS conversion
+                [("key".to_string(), "value".to_string())]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            ),
+        };
+
+        let rss_item: rss::Item = post.into();
+
+        assert_eq!(rss_item.title(), Some("Full Title"));
+        assert_eq!(rss_item.link(), Some("https://example.com/full"));
+        assert_eq!(rss_item.pub_date(), Some("Sat, 23 Mar 2024 10:00:00 +0000"));
+        assert_eq!(rss_item.guid().unwrap().value(), "test-id-full");
+        // Check description (should use the provided description)
+        assert_eq!(
+            rss_item.description(),
+            Some("This is a specific description.")
+        );
+        // Check author (should be None)
+        assert!(rss_item.author().is_none());
+        // Check categories
+        assert_eq!(rss_item.categories().len(), 2);
+        assert_eq!(rss_item.categories()[0].name(), "Category A");
+        assert_eq!(rss_item.categories()[1].name(), "Category B");
+        // Check updated_at (should be None)
+        assert!(rss_item.extensions().get(ATOM_NAMESPACE).is_none());
+        // Check content
+        assert_eq!(
+            rss_item.content(),
+            Some("This is a longer content that should not be used for the description.")
+        );
     }
 
     #[test]
     fn test_ssufid_site_data_to_rss_channel() {
-        let post = SsufidPost {
-            id: "test-id".to_string(),
-            url: "https://example.com/post".to_string(),
-            author: "Test Author".to_string(),
-            title: "Test Post".to_string(),
-            category: vec!["Test Category".to_string()],
-            created_at: datetime!(2024-03-22 12:00:00 UTC),
+        let post1 = SsufidPost {
+            // Post with full details
+            id: "site-post-1".to_string(),
+            url: "https://example.com/post1".to_string(),
+            author: Some("Site Author 1".to_string()),
+            title: "Site Post 1".to_string(),
+            description: Some("Site Post Description 1".to_string()),
+            category: vec!["Site Category 1".to_string()],
+            created_at: datetime!(2024-03-24 09:00:00 UTC),
+            updated_at: Some(datetime!(2024-03-25 09:00:00 UTC)),
+            thumbnail: Some("https://example.com/site_thumb1.png".to_string()),
+            content: "Site Content 1".to_string(),
+            attachments: vec![Attachment {
+                url: "https://example.com/site_attach1.txt".to_string(),
+                name: None,
+                mime_type: Some("text/plain".to_string()),
+            }],
+            metadata: None,
+        };
+        let post2 = SsufidPost {
+            // Post with minimal details
+            id: "site-post-2".to_string(),
+            url: "https://example.com/post2".to_string(),
+            author: None,
+            title: "Site Post 2".to_string(),
+            description: None,
+            category: vec![],
+            created_at: datetime!(2024-03-26 11:00:00 UTC),
             updated_at: None,
-            thumbnail: "https://example.com/thumbnail.jpg".to_string(),
-            content: "Test Content".to_string(),
+            thumbnail: None,
+            content: "Site Content 2".to_string(),
             attachments: vec![],
+            metadata: None,
         };
 
         let site_data = SsufidSiteData {
             title: "Test Site".to_string(),
             source: "https://example.com".to_string(),
-            description: "Test Description".to_string(),
-            items: vec![post],
+            description: "Test Site Description".to_string(),
+            items: vec![post1, post2], // Include both posts
         };
 
         let rss_channel: rss::Channel = site_data.into();
 
         assert_eq!(rss_channel.title(), "Test Site");
         assert_eq!(rss_channel.link(), "https://example.com");
-        assert_eq!(rss_channel.description(), "Test Description");
-        assert_eq!(rss_channel.items().len(), 1);
+        assert_eq!(rss_channel.description(), "Test Site Description");
+        assert_eq!(rss_channel.items().len(), 2); // Check item count
 
-        let rss_item = &rss_channel.items()[0];
-        assert_eq!(rss_item.title(), Some("Test Post"));
-        assert_eq!(rss_item.link(), Some("https://example.com/post"));
-        assert_eq!(rss_item.pub_date(), Some("Fri, 22 Mar 2024 12:00:00 +0000"));
-        assert_eq!(rss_item.guid().unwrap().value(), "test-id");
-        assert_eq!(rss_item.description(), Some("Test Content"));
-        assert_eq!(rss_item.content(), Some("Test Content"));
+        // --- Assertions for Post 1 ---
+        let rss_item1 = &rss_channel.items()[0];
+        assert_eq!(rss_item1.title(), Some("Site Post 1"));
+        assert_eq!(rss_item1.link(), Some("https://example.com/post1"));
+        assert_eq!(
+            rss_item1.pub_date(),
+            Some("Sun, 24 Mar 2024 09:00:00 +0000")
+        );
+        assert_eq!(rss_item1.guid().unwrap().value(), "site-post-1");
+        assert_eq!(rss_item1.description(), Some("Site Post Description 1"));
+        assert_eq!(rss_item1.content(), Some("Site Content 1"));
+        assert_eq!(rss_item1.author(), Some("Site Author 1"));
+        assert_eq!(rss_item1.categories().len(), 1);
+        assert_eq!(rss_item1.categories()[0].name(), "Site Category 1");
+        assert_eq!(
+            rss_item1
+                .extensions()
+                .get(ATOM_NAMESPACE)
+                .and_then(|m| m.get("atom:updated"))
+                .and_then(|v| v.first())
+                .and_then(|e| e.value()),
+            Some("2024-03-25T09:00:00Z")
+        );
+
+        // --- Assertions for Post 2 ---
+        let rss_item2 = &rss_channel.items()[1];
+        assert_eq!(rss_item2.title(), Some("Site Post 2"));
+        assert_eq!(rss_item2.link(), Some("https://example.com/post2"));
+        assert_eq!(
+            rss_item2.pub_date(),
+            Some("Tue, 26 Mar 2024 11:00:00 +0000")
+        );
+        assert_eq!(rss_item2.guid().unwrap().value(), "site-post-2");
+        assert_eq!(rss_item2.description(), Some("Site Content 2")); // Fallback description
+        assert_eq!(rss_item2.content(), Some("Site Content 2"));
+        assert!(rss_item2.author().is_none());
+        assert!(rss_item2.categories().is_empty());
+        assert!(rss_item2.extensions().get(ATOM_NAMESPACE).is_none()); // No updated_at
+        assert!(rss_item2.enclosure().is_none()); // No thumbnail or attachments
     }
 }

--- a/src/core/rss.rs
+++ b/src/core/rss.rs
@@ -49,10 +49,14 @@ impl From<SsufidPost> for rss::Item {
         }
 
         if let Some(thumbnail_url) = post.thumbnail {
+            let mime_type = mime_guess::from_path(&thumbnail_url)
+                .first()
+                .map(|m| m.to_string()) // 추론 실패 시 기본값 사용
+                .unwrap_or("image/*".to_string());
             builder.enclosure(Enclosure {
                 url: thumbnail_url,
-                length: "0".to_string(),          // Length is often unknown
-                mime_type: "image/*".to_string(), // Generic image type
+                length: "0".to_string(), // Length is often unknown
+                mime_type,
             });
         }
         // TODO: use media extension to iterate over attachments


### PR DESCRIPTION
## #️⃣연관된 이슈

Resolved #84 
Resolved #80

## 📝작업 내용

- [X] SsufidPost의 정의를 #84 에 맞게 변경
- [X] 변경한 데이터에 맞게 변환 과정 수정
- [ ] 변경된 스키마 필드에 대한 테스트 작성

## 💬리뷰 요구사항(선택)

- 파일의 제목 등을 표현하기 위한 `Attachment` 자료형을 도입했습니다.
  - 파일의 형태를 rss `Enclosure`에서 알아야 해서 `mime_type` 필드도 옵셔널하게 추가했는데, 이를 플러그인에서 알아내서 넣어줄 수 있을까요?

테스트는 변경사항 리뷰 후 좀 더 보강 예정