### PR TITLE
[feat] 정보보호학과 플러그인

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use ssufid::{
             graduate::CseGraduatePlugin,
         },
         media::MediaPlugin,
+        sec::SecPlugin,
         ssu_catch::SsuCatchPlugin,
         ssu_path::{SsuPathCredential, SsuPathPlugin},
         sw::{bachelor::SwBachelorPlugin, graduate::SwGraduatePlugin},
@@ -97,6 +98,7 @@ pub enum SsufidPluginRegistry {
     Media(MediaPlugin),
     SwBachelor(SwBachelorPlugin),
     SwGraduate(SwGraduatePlugin),
+    SecBachelor(SecPlugin),
 }
 
 impl SsufidPluginRegistry {
@@ -130,6 +132,9 @@ impl SsufidPluginRegistry {
                 save_run(core, out_dir, plugin, posts_limit, retry_count).await
             }
             SsufidPluginRegistry::SwGraduate(plugin) => {
+                save_run(core, out_dir, plugin, posts_limit, retry_count).await
+            }
+            SsufidPluginRegistry::SecBachelor(plugin) => {
                 save_run(core, out_dir, plugin, posts_limit, retry_count).await
             }
         }
@@ -186,6 +191,10 @@ fn construct_tasks(
         (
             SwGraduatePlugin::IDENTIFIER,
             SsufidPluginRegistry::SwGraduate(SwGraduatePlugin::default()),
+        ),
+        (
+            SecPlugin::IDENTIFIER,
+            SsufidPluginRegistry::SecBachelor(SecPlugin::default()),
         ),
     ];
 

--- a/src/plugins/common/it_crawler.rs
+++ b/src/plugins/common/it_crawler.rs
@@ -52,7 +52,7 @@ impl ItSelectors {
             author: Selector::parse("td.td_name.sv_use > span").unwrap(),
             created_at: Selector::parse("td.td_datetime").unwrap(),
             category: Selector::parse("td.td_num2 > p").unwrap(),
-            title: Selector::parse("#bo_v_title > span").unwrap(),
+            title: Selector::parse("#bo_v_title > span.bo_v_tit").unwrap(),
             thumbnail: Selector::parse("#bo_v_con img").unwrap(),
             content: Selector::parse("#bo_v_con").unwrap(),
             attachments: Selector::parse("#bo_v_file > ul > li > a").unwrap(),

--- a/src/plugins/common/it_crawler.rs
+++ b/src/plugins/common/it_crawler.rs
@@ -227,9 +227,10 @@ where
             .select(&self.selectors.title)
             .next()
             .map(|span| span.text().collect::<String>().trim().to_string())
-            .ok_or(PluginError::parse::<T>(
-                "Title element not found".to_string(),
-            ))?;
+            .ok_or(PluginError::parse::<T>(format!(
+                "Title element not found: URL {}",
+                metadata.url
+            )))?;
 
         let thumbnail = document
             .select(&self.selectors.thumbnail)
@@ -239,9 +240,10 @@ where
         let content = document
             .select(&self.selectors.content)
             .next()
-            .ok_or(PluginError::parse::<T>(
-                "Content element not found".to_string(),
-            ))?
+            .ok_or(PluginError::parse::<T>(format!(
+                "Content element not found: URL {}",
+                metadata.url
+            )))?
             .child_elements()
             .map(|p| p.html())
             .collect::<Vec<String>>()

--- a/src/plugins/common/it_crawler.rs
+++ b/src/plugins/common/it_crawler.rs
@@ -1,7 +1,7 @@
 // IT대학의 컴퓨터학부, 소프트웨어학부, 정보보호학과에
 // 해당하는 플러그인에서 사용되는 공통 모듈입니다.
 
-use futures::{TryStreamExt, stream::FuturesUnordered};
+use futures::{TryStreamExt, stream::FuturesOrdered};
 use log::{info, warn};
 use scraper::{Html, Selector};
 use thiserror::Error;
@@ -102,7 +102,7 @@ where
         metadata_list
             .iter()
             .map(|metadata| self.fetch_post(metadata))
-            .collect::<FuturesUnordered<_>>()
+            .collect::<FuturesOrdered<_>>()
             .try_collect::<Vec<_>>()
             .await
     }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,5 +1,6 @@
 pub mod cse;
 pub mod media;
+pub mod sec;
 pub mod ssu_catch;
 pub mod ssu_path;
 pub mod sw;

--- a/src/plugins/sec.rs
+++ b/src/plugins/sec.rs
@@ -1,0 +1,48 @@
+use crate::plugins::common::it_crawler::ItCrawler;
+use crate::{
+    PluginError,
+    core::{SsufidPlugin, SsufidPost},
+};
+
+pub struct SecPlugin {
+    crawler: ItCrawler<Self>,
+}
+
+impl SsufidPlugin for SecPlugin {
+    const IDENTIFIER: &'static str = "sec.ssu.ac.kr";
+    const TITLE: &'static str = "숭실대학교 정보보호학과 공지사항";
+    const DESCRIPTION: &'static str = "숭실대학교 정보보호학과 홈페이지의 공지사항을 제공합니다.";
+    const BASE_URL: &'static str = "https://sec.ssu.ac.kr/bbs/board.php?bo_table=notice";
+
+    async fn crawl(&self, posts_limit: u32) -> Result<Vec<SsufidPost>, PluginError> {
+        self.crawler.crawl(posts_limit).await
+    }
+}
+
+impl Default for SecPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SecPlugin {
+    fn new() -> Self {
+        Self {
+            crawler: ItCrawler::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_crawl() {
+        let posts_limit = 100;
+        let plugin = SecPlugin::new();
+        let posts = plugin.crawl(posts_limit).await.unwrap();
+        assert!(posts.len() <= posts_limit as usize);
+        // println!("{:#?}", posts);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves #91 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- it_crawler 모듈을 사용하여 정보보호학과 공지사항 플러그인 추가
  - 제목의 셀렉터를 더 구체적으로 수정했습니다
- 결과의 게시글 순서가 뒤죽박죽인 문제를 해결하기 위해 `collect::<FuturesOrdered<_>>()`로 수정했습니다.
  - @EATSTEAK p4) ssu_path도 FuturesOrdered로 바꾸는 게 어떨까요?
```diff
metadata_list
            .iter()
            .map(|metadata| self.fetch_post(metadata))
-            .collect::<FuturesUnordered<_>>()
+            .collect::<FuturesOrdered<_>>()
            .try_collect::<Vec<_>>()
            .await
```

## 💬리뷰 요구사항(선택)

