### PR TITLE
[feat] 데이터가 append 되도록 수정

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,19 +3,19 @@ name: Lint
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
       - name: Retrieve cache
         uses: Leafwing-Studios/cargo-cache@v2
       - name: Check rustfmt
-        run: cargo +nightly fmt
+        run: cargo fmt
       - name: Check clippy
-        run: cargo +nightly clippy -- -D warnings
+        run: cargo clippy -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,12 +1089,13 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1965,6 +1966,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -2065,6 +2067,7 @@ name = "ssufid"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "indexmap",
  "log",
  "mime_guess",
  "reqwest",

--- a/packages/ssufid/Cargo.toml
+++ b/packages/ssufid/Cargo.toml
@@ -23,7 +23,7 @@ reqwest = { workspace = true, features = [
 ] }
 scraper = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror = { workspace = true }
 time = { workspace = true, features = [
     "serde",
@@ -37,6 +37,7 @@ url = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 mime_guess = { workspace = true }
+indexmap = { version = "2.9.0", features = ["serde"] }
 
 [dev-dependencies]
 time = { workspace = true, features = ["macros"] }

--- a/packages/ssufid/src/core/mod.rs
+++ b/packages/ssufid/src/core/mod.rs
@@ -202,7 +202,7 @@ fn merge_entries(
     old_entries_map
         .sort_by(|_k, v, _k2, v2| v.partial_cmp(v2).unwrap_or(std::cmp::Ordering::Equal));
     let current_time = time::OffsetDateTime::now_utc();
-    new_entries.sort_by(|a, b| a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal));
+    new_entries.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let new_entries = new_entries;
     for post in new_entries.into_iter() {
         if post.updated_at.is_some() {

--- a/packages/ssufid/src/core/mod.rs
+++ b/packages/ssufid/src/core/mod.rs
@@ -215,6 +215,7 @@ fn merge_entries(
                 old_entries_map.insert(
                     post.id.clone(),
                     SsufidPost {
+                        created_at: old.created_at,
                         updated_at: Some(current_time),
                         ..post
                     },


### PR DESCRIPTION
## #️⃣연관된 이슈

Resolved #85
Resolved #99

## 📝작업 내용

- 데이터가 append 되도록 로직을 변경했습니다.
- 데이터를 created_at 기준으로 정렬했습니다.
- json과 rss는 최근 100개의 포스트만 보여줍니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
