### PR TITLE
[feat] `tracing`을 이용한 구조적 로깅

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,29 +529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,30 +1056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jiff"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1149,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1227,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-conv"
@@ -1345,6 +1317,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -1450,21 +1428,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1662,8 +1625,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1674,8 +1646,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2042,7 +2020,6 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "indexmap",
- "log",
  "mime_guess",
  "reqwest",
  "rss",
@@ -2052,6 +2029,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -2061,10 +2039,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "color-eyre",
- "env_logger",
  "eyre",
  "futures",
- "log",
  "serde",
  "serde_json",
  "ssufid",
@@ -2075,6 +2051,8 @@ dependencies = [
  "ssufid_ssupath",
  "time",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2082,7 +2060,6 @@ name = "ssufid_itsites"
 version = "0.1.0"
 dependencies = [
  "futures",
- "log",
  "reqwest",
  "scraper",
  "serde",
@@ -2091,6 +2068,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -2099,7 +2077,6 @@ name = "ssufid_media"
 version = "0.1.0"
 dependencies = [
  "futures",
- "log",
  "reqwest",
  "scraper",
  "serde",
@@ -2107,6 +2084,7 @@ dependencies = [
  "ssufid",
  "time",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -2115,7 +2093,6 @@ name = "ssufid_mediamba"
 version = "0.1.0"
 dependencies = [
  "futures",
- "log",
  "reqwest",
  "scraper",
  "serde",
@@ -2124,6 +2101,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -2132,7 +2110,6 @@ name = "ssufid_ssucatch"
 version = "0.1.0"
 dependencies = [
  "futures",
- "log",
  "reqwest",
  "scraper",
  "serde",
@@ -2141,6 +2118,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -2150,7 +2128,6 @@ version = "0.1.0"
 dependencies = [
  "dotenvy",
  "futures",
- "log",
  "reqwest",
  "scraper",
  "serde",
@@ -2160,6 +2137,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -2443,7 +2421,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2467,14 +2457,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2692,6 +2713,28 @@ checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full"] }
 url = "2.5.4"
 futures = "0.3.31"
-log = "0.4.27"
+tracing = "0.1.41"
 mime_guess = "2.0.5"
 
 ssufid = { path = "packages/ssufid", features = ["rss"] }

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -18,7 +18,7 @@ time = { workspace = true, features = [
   "parsing",
 ] }
 futures = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full", "rt-multi-thread"] }
 clap = { version = "4.5.36", features = ["derive"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -20,8 +20,8 @@ time = { workspace = true, features = [
 futures = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 clap = { version = "4.5.36", features = ["derive"] }
-log = { workspace = true }
-env_logger = "0.11.8"
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 
 ssufid = { workspace = true }
 ssufid_itsites = { workspace = true }

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -286,6 +286,7 @@ fn setup_tracing() -> eyre::Result<()> {
         .map_err(|e| eyre::eyre!("Failed to create log file: {e}"))?;
     let content_report_layer = tracing_subscriber::fmt::layer()
         .json()
+        .with_span_list(false)
         .with_writer(Arc::new(content_report_file))
         .with_filter(filter::filter_fn(|metadata| {
             metadata.target() == "content_update"

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -291,9 +291,18 @@ fn setup_tracing() -> eyre::Result<()> {
         .with_filter(filter::filter_fn(|metadata| {
             metadata.target() == "content_update"
         }));
+
+    let error_report_file = File::create("error_report.json")
+        .map_err(|e| eyre::eyre!("Failed to create error log file: {e}"))?;
+    let error_report_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(Arc::new(error_report_file))
+        .with_filter(LevelFilter::ERROR);
+
     tracing_subscriber::registry()
         .with(stdout_log)
         .with(content_report_layer)
+        .with(error_report_layer)
         .init();
     Ok(())
 }

--- a/packages/ssufid/Cargo.toml
+++ b/packages/ssufid/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { workspace = true, features = ["full"] }
 rss = { version = "2.0", optional = true }
 url = { workspace = true }
 futures = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 mime_guess = { workspace = true }
 indexmap = { version = "2.9.0", features = ["serde"] }
 

--- a/packages/ssufid/src/core/mod.rs
+++ b/packages/ssufid/src/core/mod.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use log::{error, info};
 use serde::{Deserialize, Serialize};
 use time;
 use tokio::sync::RwLock;
@@ -108,12 +107,12 @@ impl SsufidCore {
             let result = self
                 .run(plugin, posts_limit)
                 .await
-                .inspect_err(|e| error!("{e:?} [Attempt {attempt}/{retry_count}]"));
+                .inspect_err(|e| tracing::error!("{e:?} [Attempt {attempt}/{retry_count}]"));
 
             if let Ok(data) = &result {
                 let elapsed = start.elapsed();
 
-                info!(
+                tracing::info!(
                     "[{}] Successfully crawled {} posts in {:.2}s",
                     T::IDENTIFIER,
                     data.items.len(),

--- a/plugins/it_sites/Cargo.toml
+++ b/plugins/it_sites/Cargo.toml
@@ -30,7 +30,7 @@ time = { workspace = true, features = [
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 futures = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 ssufid = { workspace = true }
 
 [dev-dependencies]

--- a/plugins/it_sites/src/common/it_crawler.rs
+++ b/plugins/it_sites/src/common/it_crawler.rs
@@ -93,11 +93,7 @@ where
 
     pub(crate) async fn crawl(&self, posts_limit: u32) -> Result<Vec<SsufidPost>, PluginError> {
         let metadata_list = self.fetch_metadata_list(posts_limit).await?;
-        tracing::info!(
-            "[{}] fetch {} post contents",
-            T::IDENTIFIER,
-            metadata_list.len()
-        );
+        tracing::info!("fetch {} post contents", metadata_list.len());
         metadata_list
             .iter()
             .map(|metadata| self.fetch_post(metadata))
@@ -113,7 +109,7 @@ where
         let mut metadata_list: Vec<ItMetadata> = vec![];
 
         while remain > 0 {
-            tracing::info!("[{}] page: {}", T::IDENTIFIER, page);
+            tracing::info!(page);
             let mut metadata = self
                 .fetch_metadata(page)
                 .await?
@@ -202,9 +198,7 @@ where
             .filter_map(|result: Result<ItMetadata, ItMetadataError>| {
                 // 경고 메시지 모아서 출력
                 // 메타데이터 크롤링 실패 시 크롤링 대상에서 제외
-                result
-                    .inspect_err(|e| tracing::warn!("[{}] {:?}", T::IDENTIFIER, e))
-                    .ok()
+                result.inspect_err(|e| tracing::warn!("{:?}", e)).ok()
             })
             .collect::<Vec<ItMetadata>>();
 

--- a/plugins/it_sites/src/common/it_crawler.rs
+++ b/plugins/it_sites/src/common/it_crawler.rs
@@ -198,7 +198,9 @@ where
             .filter_map(|result: Result<ItMetadata, ItMetadataError>| {
                 // 경고 메시지 모아서 출력
                 // 메타데이터 크롤링 실패 시 크롤링 대상에서 제외
-                result.inspect_err(|e| tracing::warn!("{:?}", e)).ok()
+                result
+                    .inspect_err(|e| tracing::warn!(error = ?e, "Failed to parse Metadata"))
+                    .ok()
             })
             .collect::<Vec<ItMetadata>>();
 

--- a/plugins/it_sites/src/common/it_crawler.rs
+++ b/plugins/it_sites/src/common/it_crawler.rs
@@ -2,7 +2,6 @@
 // 해당하는 플러그인에서 사용되는 공통 모듈입니다.
 
 use futures::{TryStreamExt, stream::FuturesOrdered};
-use log::{info, warn};
 use scraper::{Html, Selector};
 use thiserror::Error;
 use time::{
@@ -94,7 +93,7 @@ where
 
     pub(crate) async fn crawl(&self, posts_limit: u32) -> Result<Vec<SsufidPost>, PluginError> {
         let metadata_list = self.fetch_metadata_list(posts_limit).await?;
-        info!(
+        tracing::info!(
             "[{}] fetch {} post contents",
             T::IDENTIFIER,
             metadata_list.len()
@@ -114,7 +113,7 @@ where
         let mut metadata_list: Vec<ItMetadata> = vec![];
 
         while remain > 0 {
-            info!("[{}] page: {}", T::IDENTIFIER, page);
+            tracing::info!("[{}] page: {}", T::IDENTIFIER, page);
             let mut metadata = self
                 .fetch_metadata(page)
                 .await?
@@ -204,7 +203,7 @@ where
                 // 경고 메시지 모아서 출력
                 // 메타데이터 크롤링 실패 시 크롤링 대상에서 제외
                 result
-                    .inspect_err(|e| warn!("[{}] {:?}", T::IDENTIFIER, e))
+                    .inspect_err(|e| tracing::warn!("[{}] {:?}", T::IDENTIFIER, e))
                     .ok()
             })
             .collect::<Vec<ItMetadata>>();
@@ -292,7 +291,7 @@ mod tests {
         assert!(!metadata_list.is_empty());
 
         for metadata in &metadata_list {
-            println!("{:?}", metadata);
+            tracing::info!("{:?}", metadata);
         }
 
         let first_metadata = &metadata_list[0];

--- a/plugins/media/Cargo.toml
+++ b/plugins/media/Cargo.toml
@@ -29,7 +29,7 @@ time = { workspace = true, features = [
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 futures = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 ssufid = { workspace = true }
 
 [dev-dependencies]

--- a/plugins/mediamba/Cargo.toml
+++ b/plugins/mediamba/Cargo.toml
@@ -31,7 +31,7 @@ time = { workspace = true, features = [
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 futures = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 ssufid = { workspace = true }
 
 [dev-dependencies]

--- a/plugins/ssucatch/Cargo.toml
+++ b/plugins/ssucatch/Cargo.toml
@@ -30,7 +30,7 @@ time = { workspace = true, features = [
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 futures = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 ssufid = { workspace = true }
 
 [dev-dependencies]

--- a/plugins/ssucatch/src/lib.rs
+++ b/plugins/ssucatch/src/lib.rs
@@ -135,7 +135,7 @@ impl SsuCatchPlugin {
             })
             .filter_map(|result| {
                 result
-                    .inspect_err(|e| tracing::warn!("{:?}", e.to_string()))
+                    .inspect_err(|e| tracing::warn!(error = ?e, "Failed to parse metadata"))
                     .ok()
             })
             .collect();

--- a/plugins/ssucatch/src/lib.rs
+++ b/plugins/ssucatch/src/lib.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use futures::{StreamExt as _, stream::FuturesOrdered};
 use scraper::{Html, Selector};
 use thiserror::Error;
 use url::Url;
@@ -134,7 +135,7 @@ impl SsuCatchPlugin {
             })
             .filter_map(|result| {
                 result
-                    .inspect_err(|e| tracing::warn!("[{}] {:?}", Self::IDENTIFIER, e.to_string()))
+                    .inspect_err(|e| tracing::warn!("{:?}", e.to_string()))
                     .ok()
             })
             .collect();
@@ -259,16 +260,14 @@ impl SsufidPlugin for SsuCatchPlugin {
         let pages = posts_limit / Self::POSTS_PER_PAGE + 1;
 
         // 모든 페이지 크롤링이 완료될 때까지 대기
-        let metadata_results = futures::future::join_all((1..=pages).map(|page| {
-            tracing::info!(
-                "[{}] Crawling post metadata from page: {}/{}",
-                Self::IDENTIFIER,
-                page,
-                pages
-            );
-            self.fetch_page_posts_metadata(page)
-        }))
-        .await;
+        let metadata_results = (1..=pages)
+            .map(|page| {
+                tracing::info!("Crawling post metadata from page: {}/{}", page, pages);
+                self.fetch_page_posts_metadata(page)
+            })
+            .collect::<FuturesOrdered<_>>()
+            .collect::<Vec<_>>()
+            .await;
 
         let all_metadata = metadata_results
             .into_iter()
@@ -279,12 +278,12 @@ impl SsufidPlugin for SsuCatchPlugin {
             .collect::<Vec<SsuCatchMetadata>>();
 
         // 모든 포스트 크롤링이 완료될 때까지 대기
-        let post_results = futures::future::join_all(
-            all_metadata
-                .iter()
-                .map(|metadata| self.fetch_post(metadata)),
-        )
-        .await;
+        let post_results = all_metadata
+            .iter()
+            .map(|metadata| self.fetch_post(metadata))
+            .collect::<FuturesOrdered<_>>()
+            .collect::<Vec<_>>()
+            .await;
 
         let all_posts = post_results
             .into_iter()

--- a/plugins/ssucatch/src/lib.rs
+++ b/plugins/ssucatch/src/lib.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use log::{info, warn};
 use scraper::{Html, Selector};
 use thiserror::Error;
 use url::Url;
@@ -135,7 +134,7 @@ impl SsuCatchPlugin {
             })
             .filter_map(|result| {
                 result
-                    .inspect_err(|e| warn!("[{}] {:?}", Self::IDENTIFIER, e.to_string()))
+                    .inspect_err(|e| tracing::warn!("[{}] {:?}", Self::IDENTIFIER, e.to_string()))
                     .ok()
             })
             .collect();
@@ -261,7 +260,7 @@ impl SsufidPlugin for SsuCatchPlugin {
 
         // 모든 페이지 크롤링이 완료될 때까지 대기
         let metadata_results = futures::future::join_all((1..=pages).map(|page| {
-            info!(
+            tracing::info!(
                 "[{}] Crawling post metadata from page: {}/{}",
                 Self::IDENTIFIER,
                 page,
@@ -316,7 +315,7 @@ mod tests {
 
         let first_post_metadata = &posts_metadata[0];
 
-        println!("First post metadata: {:?}", first_post_metadata);
+        tracing::info!("First post metadata: {:?}", first_post_metadata);
 
         // ID, URL이 올바르게 추출되었는지 확인
         assert!(!first_post_metadata.id.is_empty(), "ID should not be empty");
@@ -376,7 +375,7 @@ mod tests {
         // 마지막 페이지 번호 가져오기
         let last_page = ssu_catch_plugin.get_last_page_number(&html);
 
-        println!("Last page number: {}", last_page);
+        tracing::info!("Last page number: {}", last_page);
 
         // 페이지 번호가 1 이상인지 확인
         assert!(last_page >= 1, "Last page number should be at least 1");

--- a/plugins/ssupath/Cargo.toml
+++ b/plugins/ssupath/Cargo.toml
@@ -30,7 +30,7 @@ time = { workspace = true, features = [
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 futures = { workspace = true }
-log = { workspace = true }
+tracing = { workspace = true }
 ssufid = { workspace = true }
 
 [dev-dependencies]

--- a/plugins/ssupath/src/lib.rs
+++ b/plugins/ssupath/src/lib.rs
@@ -140,11 +140,7 @@ impl SsufidPlugin for SsuPathPlugin {
         "https://path.ssu.ac.kr/ptfol/imng/icmpNsbjtPgm/findIcmpNsbjtPgmList.do";
 
     async fn crawl(&self, posts_limit: u32) -> Result<Vec<SsufidPost>, PluginError> {
-        tracing::info!(
-            "Crawling {} with {} posts limit",
-            SsuPathPlugin::IDENTIFIER,
-            posts_limit
-        );
+        tracing::info!("Crawling with {} posts limit", posts_limit);
         let pages = (posts_limit as usize).div_ceil(ENTRIES_PER_PAGE);
         tracing::info!("Crawling {pages} pages");
         let client = self.client().await?;

--- a/plugins/ssupath/src/model.rs
+++ b/plugins/ssupath/src/model.rs
@@ -155,7 +155,7 @@ impl SsuPathProgram {
                 .cloned()
                 .ok_and_parse_u32("Cannot parse miles of entry".to_string())
                 .inspect_err(|e| {
-                    log::warn!("Failed to parse miles of entry: {e:?}");
+                    tracing::warn!("Failed to parse miles of entry: {e:?}");
                 })
                 .unwrap_or(0);
             let applier = desc_info_map

--- a/plugins/ssupath/src/model.rs
+++ b/plugins/ssupath/src/model.rs
@@ -155,7 +155,7 @@ impl SsuPathProgram {
                 .cloned()
                 .ok_and_parse_u32("Cannot parse miles of entry".to_string())
                 .inspect_err(|e| {
-                    tracing::warn!("Failed to parse miles of entry: {e:?}");
+                    tracing::warn!(error = ?e, "Failed to parse miles of entry");
                 })
                 .unwrap_or(0);
             let applier = desc_info_map


### PR DESCRIPTION
## #️⃣연관된 이슈

Resolved #106
Resolved #73

## 📝작업 내용

- `tracing`을 이용한 구조적 로깅으로 전환합니다.
- 기본적으로 `stdout`을 통해 로깅을 진행합니다.
- `target: "content_update"` 인 경우 `content_report.json`에 해당 정보를 로깅합니다.
  - `type` attribute로 이번 실행에 어떤 이벤트가 발생했는지 확인할 수 있습니다.
- `ERROR` 레벨 이상의 이벤트가 발생한 경우 `error_report.json`에 해당 정보를 로깅합니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
