### PR TITLE
chore: reduce posts_limit to 20 in tests

### DIFF
--- a/plugins/common/src/lib.rs
+++ b/plugins/common/src/lib.rs
@@ -121,7 +121,7 @@ macro_rules! test_sites {
             $(
                 #[tokio::test]
                 async fn $test_name() {
-                    let posts_limit = 100;
+                    let posts_limit = 20;
                     let plugin = <$plugin>::new();
                     let posts = plugin.crawl(posts_limit).await.unwrap();
                     assert!(posts.len() <= posts_limit as usize);


### PR DESCRIPTION
## #️⃣연관된 이슈

X

## 📝작업 내용

- 부하를 줄이기 위해 테스트에서 가져오는 포스트의 갯수를 20개로 제한합니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
