### PR TITLE
[feat(cli)] calendar 출력 경로 및 기본 범위 개선

### DIFF
--- a/packages/cli/src/macros.rs
+++ b/packages/cli/src/macros.rs
@@ -13,6 +13,7 @@ macro_rules! register_plugins {
                 self,
                 core: Arc<ssufid::SsufidCore>,
                 out_dir: &Path,
+                calendar_out_dir: &Path,
                 posts_limit: u32,
                 calendar_range: ssufid::core::CalendarCrawlRange,
                 retry_count: u32,
@@ -25,7 +26,7 @@ macro_rules! register_plugins {
                     $(Self::$calendar_id(plugin) => {
                         crate::save_calendar_run(
                             core,
-                            out_dir,
+                            calendar_out_dir,
                             plugin,
                             calendar_range,
                             retry_count,
@@ -38,6 +39,7 @@ macro_rules! register_plugins {
         fn construct_tasks(
             core: Arc<SsufidCore>,
             out_dir: &Path,
+            calendar_out_dir: &Path,
             options: SsufidDaemonOptions,
             calendar_range: ssufid::core::CalendarCrawlRange,
         ) -> Vec<impl std::future::Future<Output = eyre::Result<()>>> {
@@ -73,6 +75,7 @@ macro_rules! register_plugins {
                         include.contains(id).then_some(task.save_run(
                             core.clone(),
                             out_dir,
+                            calendar_out_dir,
                             options.posts_limit,
                             calendar_range.clone(),
                             options.retry_count,
@@ -86,6 +89,7 @@ macro_rules! register_plugins {
                         exclude.contains(id).not().then_some(task.save_run(
                             core.clone(),
                             out_dir,
+                            calendar_out_dir,
                             options.posts_limit,
                             calendar_range.clone(),
                             options.retry_count,
@@ -99,6 +103,7 @@ macro_rules! register_plugins {
                         task.save_run(
                             core.clone(),
                             out_dir,
+                            calendar_out_dir,
                             options.posts_limit,
                             calendar_range.clone(),
                             options.retry_count,

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -46,6 +46,10 @@ struct SsufidDaemonOptions {
     #[arg(short = 'o', long = "out", default_value = "./out")]
     out_dir: String,
 
+    /// The output directory for calendar data.
+    #[arg(long = "calendar-out", default_value = "./out/calendar")]
+    calendar_out_dir: String,
+
     /// The cache directory for the fetched data.
     #[arg(long = "cache", default_value = "./.cache")]
     cache_dir: String,
@@ -89,10 +93,17 @@ async fn main() -> eyre::Result<()> {
 
     let calendar_range = calendar_crawl_range_from_options(&options)?;
     let out_dir = Path::new(&options.out_dir).to_owned();
+    let calendar_out_dir = Path::new(&options.calendar_out_dir).to_owned();
 
     let core = Arc::new(SsufidCore::new(&options.cache_dir));
 
-    let tasks = construct_tasks(core.clone(), &out_dir, options, calendar_range);
+    let tasks = construct_tasks(
+        core.clone(),
+        &out_dir,
+        &calendar_out_dir,
+        options,
+        calendar_range,
+    );
     let tasks_len = tasks.len();
 
     // Run all tasks and collect errors

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -24,7 +24,7 @@ use ssufid_startup::StartupPlugin;
 use ssufid_stu::StuPlugin;
 use ssufid_study::StudyPlugin;
 use time::{
-    Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset,
+    Date, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset,
     macros::{format_description, offset},
 };
 use tokio::io::AsyncWriteExt;
@@ -267,9 +267,11 @@ fn calendar_crawl_range_from_options(
 
 fn default_calendar_crawl_range() -> eyre::Result<CalendarCrawlRange> {
     let now = OffsetDateTime::now_utc().to_offset(kst_offset());
-    let start_date = now.date() - Duration::days(SsufidCore::CALENDAR_DAY_LIMIT as i64);
+    let year = now.year();
+    let start_date = Date::from_calendar_date(year, Month::January, 1)?;
+    let end_date = Date::from_calendar_date(year + 1, Month::December, 31)?;
     let start = PrimitiveDateTime::new(start_date, Time::MIDNIGHT).assume_offset(kst_offset());
-    let end = PrimitiveDateTime::new(now.date(), end_of_day()).assume_offset(kst_offset());
+    let end = PrimitiveDateTime::new(end_date, end_of_day()).assume_offset(kst_offset());
 
     CalendarCrawlRange::new(start, end).map_err(eyre::Error::msg)
 }


### PR DESCRIPTION
## Summary
- calendar 데이터가 일반 플러그인 출력 경로와 분리되도록 `--calendar-out` 옵션을 추가했습니다.
- `--calendar-out`의 기본 경로를 `./out/calendar`로 설정했습니다.
- 기본 calendar crawl 범위를 올해 1월 1일부터 내년 12월 31일까지로 확장했습니다.

## Test plan
- [x] `cargo check -p ssufid_cli`
- [x] `cargo run -p ssufid_cli -- --help`